### PR TITLE
Feat/text unmarshaler support

### DIFF
--- a/clix.go
+++ b/clix.go
@@ -1,9 +1,14 @@
 package clix
 
 import (
+	"encoding"
 	"reflect"
 	"time"
 )
+
+// textUnmarshalerType is the reflect.Type of encoding.TextUnmarshaler, used to
+// detect fields that can parse themselves from a string.
+var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 
 // ContextReader defines the interface for reading values from a CLI context.
 // This abstraction allows for easier testing by allowing mock implementations.
@@ -103,6 +108,13 @@ func AssignValueToCliFields(v interface{}, prefix string, c ContextReader) {
 				continue
 			}
 
+			// Handle types that parse themselves from a string via
+			// encoding.TextUnmarshaler, e.g. a custom byte-size type parsing
+			// values like "10 MB" or "1 GB".
+			if setTextUnmarshalerValue(c, fullTag, field) {
+				continue
+			}
+
 			// Handle other types based on their Kind
 			setFieldValue(c, fullTag, field)
 		}
@@ -120,6 +132,34 @@ func setTimeValue(c ContextReader, tag string, field reflect.Value) {
 			field.Set(reflect.ValueOf(*t))
 		}
 	}
+}
+
+// setTextUnmarshalerValue handles fields whose type knows how to parse itself
+// from a string through encoding.TextUnmarshaler
+func setTextUnmarshalerValue(c ContextReader, tag string, field reflect.Value) bool {
+	t := field.Type()
+	switch {
+	// Pointer field, e.g. *bytesize.ByteSize: allocate then unmarshal.
+	case t.Kind() == reflect.Ptr && t.Implements(textUnmarshalerType):
+		raw := c.String(tag)
+		if raw == "" {
+			return true
+		}
+		ptr := reflect.New(t.Elem())
+		if err := ptr.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(raw)); err == nil {
+			field.Set(ptr)
+		}
+		return true
+	// Value field whose pointer implements the interface, e.g. bytesize.ByteSize.
+	case t.Kind() != reflect.Ptr && reflect.PointerTo(t).Implements(textUnmarshalerType):
+		raw := c.String(tag)
+		if raw == "" {
+			return true
+		}
+		_ = field.Addr().Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(raw))
+		return true
+	}
+	return false
 }
 
 // setFieldValue sets the value of a field based on its Kind.

--- a/clix.go
+++ b/clix.go
@@ -108,9 +108,7 @@ func AssignValueToCliFields(v interface{}, prefix string, c ContextReader) {
 				continue
 			}
 
-			// Handle types that parse themselves from a string via
-			// encoding.TextUnmarshaler, e.g. a custom byte-size type parsing
-			// values like "10 MB" or "1 GB".
+			// Handle types that implement encoding.TextUnmarshaler
 			if setTextUnmarshalerValue(c, fullTag, field) {
 				continue
 			}

--- a/clix.go
+++ b/clix.go
@@ -139,7 +139,7 @@ func setTimeValue(c ContextReader, tag string, field reflect.Value) {
 func setTextUnmarshalerValue(c ContextReader, tag string, field reflect.Value) bool {
 	t := field.Type()
 	switch {
-	// Pointer field, e.g. *bytesize.ByteSize: allocate then unmarshal.
+	// Pointer field
 	case t.Kind() == reflect.Ptr && t.Implements(textUnmarshalerType):
 		raw := c.String(tag)
 		if raw == "" {
@@ -150,7 +150,7 @@ func setTextUnmarshalerValue(c ContextReader, tag string, field reflect.Value) b
 			field.Set(ptr)
 		}
 		return true
-	// Value field whose pointer implements the interface, e.g. bytesize.ByteSize.
+	// Value field
 	case t.Kind() != reflect.Ptr && reflect.PointerTo(t).Implements(textUnmarshalerType):
 		raw := c.String(tag)
 		if raw == "" {

--- a/clix_test.go
+++ b/clix_test.go
@@ -1,6 +1,8 @@
 package clix
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -227,6 +229,39 @@ func TestParseMixedConfig(t *testing.T) {
 	assert.Equal(t, "db.example.com", config.Database.Host)
 	assert.Equal(t, 3306, config.Database.Port)
 	assert.Equal(t, []string{"replica1", "replica2", "replica3"}, config.Database.Replicas)
+}
+
+// kib - minimal encoding.TextUnmarshaler
+type kib int64
+
+func (k *kib) UnmarshalText(text []byte) error {
+	n, err := strconv.ParseInt(strings.TrimSuffix(string(text), "K"), 10, 64)
+	if err != nil {
+		return err
+	}
+	*k = kib(n * 1024)
+	return nil
+}
+
+type SizeConfig struct {
+	CacheSize    *kib `cli:"cache-size"`
+	BufferSize   kib  `cli:"buffer-size"`
+	UnsetSize    kib  `cli:"unset-size"`
+	UnsetSizePtr *kib `cli:"unset-size-ptr"`
+}
+
+func TestParseTextUnmarshalerTypes(t *testing.T) {
+	ctx := newMockContext()
+	ctx.stringMap["cache-size"] = "10K"
+	ctx.stringMap["buffer-size"] = "4K"
+
+	config := Parse[SizeConfig](ctx)
+
+	assert.NotNil(t, config.CacheSize)
+	assert.Equal(t, kib(10*1024), *config.CacheSize)
+	assert.Equal(t, kib(4*1024), config.BufferSize)
+	assert.Zero(t, config.UnsetSize)
+	assert.Nil(t, config.UnsetSizePtr)
 }
 
 func TestMissingValues(t *testing.T) {


### PR DESCRIPTION
Support struct fields implementing [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler).

For example https://github.com/inhies/go-bytesize:

```go
type MyConfig struct {
    SomeSize *bytesize.ByteSize `cli:"some-size"`
}
```

```sh
$ ./myprogram --some-size="1024 KB"
```